### PR TITLE
Add basic finance management API with JWT security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,20 +34,42 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                        <version>0.12.5</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <version>0.12.5</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <version>0.12.5</version>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/com/example/FinanceApp/config/SecurityConfig.java
+++ b/src/main/java/com/example/FinanceApp/config/SecurityConfig.java
@@ -1,24 +1,50 @@
 package com.example.FinanceApp.config;
 
 
+import com.example.FinanceApp.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
+        this.jwtFilter = jwtFilter;
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated()
                 )
-                .csrf(csrf -> csrf.disable());  // disable CSRF for simplicity in testing
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
 

--- a/src/main/java/com/example/FinanceApp/controller/AuthController.java
+++ b/src/main/java/com/example/FinanceApp/controller/AuthController.java
@@ -1,0 +1,40 @@
+package com.example.FinanceApp.controller;
+
+import com.example.FinanceApp.security.JwtUtil;
+import com.example.FinanceApp.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+    private final AuthenticationManager authenticationManager;
+
+    public AuthController(UserService userService, JwtUtil jwtUtil, AuthenticationManager authenticationManager) {
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+        this.authenticationManager = authenticationManager;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestParam String username, @RequestParam String password) {
+        userService.register(username, password);
+        String token = jwtUtil.generateToken(username);
+        return ResponseEntity.ok(Map.of("token", token));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestParam String username, @RequestParam String password) {
+        Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+        String token = jwtUtil.generateToken(authentication.getName());
+        return ResponseEntity.ok(Map.of("token", token));
+    }
+}

--- a/src/main/java/com/example/FinanceApp/controller/BudgetController.java
+++ b/src/main/java/com/example/FinanceApp/controller/BudgetController.java
@@ -1,0 +1,45 @@
+package com.example.FinanceApp.controller;
+
+import com.example.FinanceApp.model.Budget;
+import com.example.FinanceApp.model.User;
+import com.example.FinanceApp.service.BudgetService;
+import com.example.FinanceApp.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
+
+@RestController
+@RequestMapping("/api/budgets")
+public class BudgetController {
+
+    private final BudgetService service;
+    private final UserService userService;
+
+    public BudgetController(BudgetService service, UserService userService) {
+        this.service = service;
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public Budget create(@AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails,
+                         @RequestParam String month,
+                         @RequestParam Double limit) {
+        User user = userService.findByUsername(userDetails.getUsername());
+        Budget budget = new Budget();
+        budget.setUser(user);
+        budget.setMonth(YearMonth.parse(month));
+        budget.setLimitAmount(limit);
+        return service.save(budget);
+    }
+
+    @GetMapping("/{month}")
+    public ResponseEntity<Budget> get(@AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails,
+                                      @PathVariable String month) {
+        User user = userService.findByUsername(userDetails.getUsername());
+        return service.find(user, YearMonth.parse(month))
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/example/FinanceApp/controller/TransactionController.java
+++ b/src/main/java/com/example/FinanceApp/controller/TransactionController.java
@@ -1,0 +1,48 @@
+package com.example.FinanceApp.controller;
+
+import com.example.FinanceApp.model.Transaction;
+import com.example.FinanceApp.model.User;
+import com.example.FinanceApp.service.TransactionService;
+import com.example.FinanceApp.service.UserService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/transactions")
+public class TransactionController {
+
+    private final TransactionService service;
+    private final UserService userService;
+
+    public TransactionController(TransactionService service, UserService userService) {
+        this.service = service;
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public Transaction create(@AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails,
+                              @RequestBody Transaction transaction) {
+        User user = userService.findByUsername(userDetails.getUsername());
+        transaction.setUser(user);
+        return service.save(transaction);
+    }
+
+    @GetMapping
+    public List<Transaction> list(@AuthenticationPrincipal org.springframework.security.core.userdetails.User userDetails,
+                                  @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+                                  @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        User user = userService.findByUsername(userDetails.getUsername());
+        return service.list(user, start, end);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/FinanceApp/model/Budget.java
+++ b/src/main/java/com/example/FinanceApp/model/Budget.java
@@ -1,0 +1,28 @@
+package com.example.FinanceApp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.YearMonth;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Budget {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // stored as YYYY-MM to simplify persistence
+    private YearMonth month;
+    private Double limitAmount;
+}

--- a/src/main/java/com/example/FinanceApp/model/Role.java
+++ b/src/main/java/com/example/FinanceApp/model/Role.java
@@ -1,0 +1,20 @@
+package com.example.FinanceApp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/com/example/FinanceApp/model/Transaction.java
+++ b/src/main/java/com/example/FinanceApp/model/Transaction.java
@@ -1,0 +1,36 @@
+package com.example.FinanceApp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Transaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Double amount;
+    private String description;
+    private String category;
+    private LocalDate date;
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    public enum Type {
+        INCOME,
+        EXPENSE
+    }
+}

--- a/src/main/java/com/example/FinanceApp/model/User.java
+++ b/src/main/java/com/example/FinanceApp/model/User.java
@@ -1,0 +1,36 @@
+package com.example.FinanceApp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
+}

--- a/src/main/java/com/example/FinanceApp/model/YearMonthAttributeConverter.java
+++ b/src/main/java/com/example/FinanceApp/model/YearMonthAttributeConverter.java
@@ -1,0 +1,19 @@
+package com.example.FinanceApp.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.YearMonth;
+
+@Converter(autoApply = true)
+public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        return attribute != null ? attribute.toString() : null;
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+        return dbData != null ? YearMonth.parse(dbData) : null;
+    }
+}

--- a/src/main/java/com/example/FinanceApp/repository/BudgetRepository.java
+++ b/src/main/java/com/example/FinanceApp/repository/BudgetRepository.java
@@ -1,0 +1,12 @@
+package com.example.FinanceApp.repository;
+
+import com.example.FinanceApp.model.Budget;
+import com.example.FinanceApp.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.YearMonth;
+import java.util.Optional;
+
+public interface BudgetRepository extends JpaRepository<Budget, Long> {
+    Optional<Budget> findByUserAndMonth(User user, YearMonth month);
+}

--- a/src/main/java/com/example/FinanceApp/repository/RoleRepository.java
+++ b/src/main/java/com/example/FinanceApp/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package com.example.FinanceApp.repository;
+
+import com.example.FinanceApp.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(String name);
+}

--- a/src/main/java/com/example/FinanceApp/repository/TransactionRepository.java
+++ b/src/main/java/com/example/FinanceApp/repository/TransactionRepository.java
@@ -1,0 +1,12 @@
+package com.example.FinanceApp.repository;
+
+import com.example.FinanceApp.model.Transaction;
+import com.example.FinanceApp.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+    List<Transaction> findByUserAndDateBetween(User user, LocalDate start, LocalDate end);
+}

--- a/src/main/java/com/example/FinanceApp/repository/UserRepository.java
+++ b/src/main/java/com/example/FinanceApp/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.FinanceApp.repository;
+
+import com.example.FinanceApp.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/example/FinanceApp/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/FinanceApp/security/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.example.FinanceApp.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                String username = jwtUtil.validateAndGetUsername(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                // invalid token, ignore
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/FinanceApp/security/JwtUtil.java
+++ b/src/main/java/com/example/FinanceApp/security/JwtUtil.java
@@ -1,0 +1,32 @@
+package com.example.FinanceApp.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private final long expirationMs = 3600_000; // 1 hour
+
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public String validateAndGetUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/com/example/FinanceApp/service/BudgetService.java
+++ b/src/main/java/com/example/FinanceApp/service/BudgetService.java
@@ -1,0 +1,26 @@
+package com.example.FinanceApp.service;
+
+import com.example.FinanceApp.model.Budget;
+import com.example.FinanceApp.model.User;
+import com.example.FinanceApp.repository.BudgetRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.util.Optional;
+
+@Service
+public class BudgetService {
+    private final BudgetRepository repository;
+
+    public BudgetService(BudgetRepository repository) {
+        this.repository = repository;
+    }
+
+    public Budget save(Budget budget) {
+        return repository.save(budget);
+    }
+
+    public Optional<Budget> find(User user, YearMonth month) {
+        return repository.findByUserAndMonth(user, month);
+    }
+}

--- a/src/main/java/com/example/FinanceApp/service/TransactionService.java
+++ b/src/main/java/com/example/FinanceApp/service/TransactionService.java
@@ -1,0 +1,30 @@
+package com.example.FinanceApp.service;
+
+import com.example.FinanceApp.model.Transaction;
+import com.example.FinanceApp.model.User;
+import com.example.FinanceApp.repository.TransactionRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class TransactionService {
+    private final TransactionRepository repository;
+
+    public TransactionService(TransactionRepository repository) {
+        this.repository = repository;
+    }
+
+    public Transaction save(Transaction transaction) {
+        return repository.save(transaction);
+    }
+
+    public List<Transaction> list(User user, LocalDate start, LocalDate end) {
+        return repository.findByUserAndDateBetween(user, start, end);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/example/FinanceApp/service/UserService.java
+++ b/src/main/java/com/example/FinanceApp/service/UserService.java
@@ -1,0 +1,58 @@
+package com.example.FinanceApp.service;
+
+import com.example.FinanceApp.model.Role;
+import com.example.FinanceApp.model.User;
+import com.example.FinanceApp.repository.RoleRepository;
+import com.example.FinanceApp.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, RoleRepository roleRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User register(String username, String password) {
+        if (userRepository.existsByUsername(username)) {
+            throw new RuntimeException("Username already taken");
+        }
+        Role role = roleRepository.findByName("ROLE_USER").orElseGet(() -> {
+            Role r = new Role();
+            r.setName("ROLE_USER");
+            return roleRepository.save(r);
+        });
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(passwordEncoder.encode(password));
+        user.setRoles(Collections.singleton(role));
+        return userRepository.save(user);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .authorities(user.getRoles().stream().map(Role::getName).toArray(String[]::new))
+                .build();
+    }
+
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username).orElseThrow();
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- implement JWT-based security configuration
- add user registration and login endpoints
- create transaction and budget APIs
- provide JPA entities and repositories for user, role, transaction and budget
- include H2 configuration for tests

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fefcf9030832f8e49af284ed1f861