### PR TITLE
Fix JWT parser builder usage

### DIFF
--- a/src/main/java/com/example/FinanceApp/security/JwtUtil.java
+++ b/src/main/java/com/example/FinanceApp/security/JwtUtil.java
@@ -24,6 +24,7 @@ public class JwtUtil {
     public String validateAndGetUsername(String token) {
         return Jwts.parser()
                 .setSigningKey(key)
+                .build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();


### PR DESCRIPTION
## Summary
- update JWT parsing to build parser before calling `parseClaimsJws`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683ff3bf9858832faf45f8846663674a