### PR TITLE
Fix user entity and JWT filter cycle

### DIFF
--- a/src/main/java/com/example/FinanceApp/config/SecurityConfig.java
+++ b/src/main/java/com/example/FinanceApp/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.example.FinanceApp.config;
 
 
 import com.example.FinanceApp.security.JwtAuthenticationFilter;
+import com.example.FinanceApp.security.JwtUtil;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -18,14 +20,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtFilter;
-
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
-        this.jwtFilter = jwtFilter;
-    }
-
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -35,6 +31,11 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        return new JwtAuthenticationFilter(jwtUtil, userDetailsService);
     }
 
     @Bean

--- a/src/main/java/com/example/FinanceApp/model/User.java
+++ b/src/main/java/com/example/FinanceApp/model/User.java
@@ -20,7 +20,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String username;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/FinanceApp/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/FinanceApp/security/JwtAuthenticationFilter.java
@@ -13,7 +13,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;


### PR DESCRIPTION
## Summary
- allow nullable `username` to avoid migration error
- refactor `SecurityConfig` to create JWT filter without circular dependency
- expose JWT filter bean and use it in the security chain
- convert `JwtAuthenticationFilter` to regular class

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683ff5534b00832fac87e8e82da351da